### PR TITLE
fix: resolve asset loading from @swrpg-online/art package

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,10 @@
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
-  moduleNameMapper: {
-    '\\.svg$': '<rootDir>/__mocks__/fileMock.js',
-    '@swrpg-online/art/(.*)': '<rootDir>/__mocks__/fileMock.js'
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
   },
+  moduleNameMapper: {
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/fileMock.js',
+  }
 }; 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swrpg-online/react-dice",
-  "version": "0.3.8",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@swrpg-online/react-dice",
-      "version": "0.3.8",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@swrpg-online/art": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "type": "module",
   "files": [
     "dist"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,47 +2,30 @@ import typescript from '@rollup/plugin-typescript';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import url from '@rollup/plugin-url';
-import { readFileSync } from 'fs';
-
-const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
 
 export default {
   input: 'src/index.ts',
   output: [
     {
-      file: pkg.main,
+      file: 'dist/index.js',
       format: 'cjs',
       sourcemap: true,
     },
     {
-      file: pkg.module,
+      file: 'dist/index.esm.js',
       format: 'esm',
       sourcemap: true,
     },
   ],
+  external: ['react', 'react-dom', '@swrpg-online/art'],
   plugins: [
-    resolve({
-      // This allows us to resolve packages from node_modules
-      moduleDirectories: ['node_modules'],
-      // Allow resolving SVG files from node_modules
-      extensions: ['.js', '.ts', '.tsx', '.svg', '.png'],
-      // Make sure we can resolve the @swrpg-online/art package
-      resolveOnly: [
-        /^(?!@swrpg-online\/art)/  // Process all imports EXCEPT @swrpg-online/art
-      ]
-    }),
     url({
       include: ['**/*.svg', '**/*.png'],
-      limit: 0, // Always generate files
-      publicPath: '',
-      destDir: 'dist/assets',
-      fileName: '[name][extname]',
+      limit: 0,
+      emitFiles: true,
     }),
+    resolve(),
     commonjs(),
-    typescript({
-      tsconfig: './tsconfig.json',
-      exclude: ['**/*.test.ts', '**/*.test.tsx'],
-    }),
+    typescript(),
   ],
-  external: ['react', 'react-dom'], // Remove @swrpg-online/art from externals
 }; 

--- a/src/Die.test.tsx
+++ b/src/Die.test.tsx
@@ -3,27 +3,44 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Die } from './Die';
 
-describe('Die', () => {
-  it('renders loading state initially', () => {
-    const { getByText } = render(<Die type="boost" />);
-    expect(getByText('Loading...')).toBeTruthy();
+describe('Die Component', () => {
+  it('renders numeric dice with correct attributes', () => {
+    const { getByAltText } = render(<Die type="d6" face={1} />);
+    const img = getByAltText('d6 die showing 1');
+    expect(img).toBeInTheDocument();
+    expect(img.getAttribute('src')).toContain('D6-01-Arabic-White.svg');
   });
 
-  it('renders loading state with proper class name and style', () => {
-    const { getByText } = render(
+  it('applies custom styling correctly', () => {
+    const { getByAltText } = render(
       <Die
-        type="ability"
+        type="d20"
+        face={1}
         className="custom-class"
         style={{ width: '100px' }}
       />
     );
-    const loadingDiv = getByText('Loading...');
-    expect(loadingDiv).toHaveClass('custom-class');
-    expect(loadingDiv).toHaveStyle({ width: '100px' });
+    const img = getByAltText('d20 die showing 1');
+    expect(img).toHaveClass('custom-class');
+    expect(img).toHaveStyle({ width: '100px' });
   });
 
   it('handles d4 variants correctly', () => {
-    const { getByText } = render(<Die type="d4" variant="apex" />);
-    expect(getByText('Loading...')).toBeInTheDocument();
+    const { getByAltText } = render(<Die type="d4" face={1} variant="apex" />);
+    const img = getByAltText('d4 die showing 1');
+    expect(img.getAttribute('src')).toContain('D4Apex-01-Arabic-White.svg');
+  });
+
+  it('renders narrative dice correctly', () => {
+    const { getByAltText } = render(<Die type="boost" face="Success" />);
+    const img = getByAltText('boost die showing Success');
+    expect(img.getAttribute('src')).toContain('Boost-Success.svg');
+  });
+
+  it('displays error state for invalid face values', () => {
+    const { getByRole } = render(<Die type="d6" face={7} />);
+    const errorDiv = getByRole('alert');
+    expect(errorDiv).toBeInTheDocument();
+    expect(errorDiv.getAttribute('title')).toContain('Invalid face for d6');
   });
 }); 

--- a/src/Die.tsx
+++ b/src/Die.tsx
@@ -114,9 +114,8 @@ const constructImagePath = (
   const isNumericDie = VALID_NUMERIC_DICE.includes(type as NumericDieType);
   const { style: themeStyle, script: themeScript } = parseTheme(theme);
   
-  // Use a relative path without leading slash for better compatibility
-  // This assumes the @swrpg-online/art package is properly installed and accessible
-  const basePath = './node_modules/@swrpg-online/art/dice';
+  // Import from @swrpg-online/art package
+  const basePath = '@swrpg-online/art/dice';
   
   if (isNumericDie) {
     const faceStr = formatFaceNumber(face as number);
@@ -180,36 +179,34 @@ export const Die: React.FC<DieProps> = ({
       // Validate die type
       const isNumericDie = VALID_NUMERIC_DICE.includes(type as NumericDieType);
       if (!isNumericDie && !['boost', 'proficiency', 'ability', 'setback', 'challenge', 'difficulty'].includes(type)) {
-        throw new Error(`Invalid die type: ${type}. Must be one of ${VALID_NUMERIC_DICE.join(', ')} or a valid narrative die type`);
+        throw new Error(`Invalid die type: ${type}`);
       }
       
       // Validate face value
       if (isNumericDie) {
         if (typeof face !== 'number') {
-          throw new Error(`Numeric dice require a number for the face value, got: ${face}`);
+          throw new Error(`Numeric dice require a number for the face value`);
         }
         
         const maxFace = getMaxFace(type as NumericDieType);
         if (type === 'd100') {
           if (face < 0 || face > maxFace || face % 10 !== 0) {
-            throw new Error(`Invalid face for d100: ${face}. Must be between 0 and 90 in steps of 10.`);
+            throw new Error(`Invalid face for d100: Must be between 0 and 90 in steps of 10`);
           }
         } else if (face < 1 || face > maxFace) {
-          throw new Error(`Invalid face for ${type}: ${face}. Must be between 1 and ${maxFace}.`);
+          throw new Error(`Invalid face for ${type}: Must be between 1 and ${maxFace}`);
         }
       } else {
         if (typeof face !== 'string') {
-          throw new Error(`Narrative dice require a string for the face value, got: ${face}`);
+          throw new Error(`Narrative dice require a string for the face value`);
         }
       }
       
       // All validation passed, construct the image path
       const imagePath = constructImagePath(type, face, theme, format, variant);
-      console.log(`Attempting to load die: ${type}, face: ${face}, path: ${imagePath}`);
       setImgSrc(imagePath);
     } catch (validationError) {
       const errorMessage = validationError instanceof Error ? validationError.message : 'Unknown error';
-      console.error(`Die validation error:`, errorMessage);
       setError(errorMessage);
       setLoadingState('error');
     }
@@ -225,21 +222,11 @@ export const Die: React.FC<DieProps> = ({
     // If SVG fails, try PNG
     if (format === 'svg' && imgSrc) {
       const pngPath = imgSrc.replace(`.${format}`, '.png');
-      console.log(`SVG failed to load, trying PNG: ${pngPath}`);
       setImgSrc(pngPath);
       return;
     }
     
-    // If the original path started with './node_modules' and failed, try without it
-    if (imgSrc && imgSrc.startsWith('./node_modules/')) {
-      const alternativePath = imgSrc.replace('./node_modules/', '');
-      console.log(`Path with node_modules failed, trying: ${alternativePath}`);
-      setImgSrc(alternativePath);
-      return;
-    }
-    
-    // If all attempts failed, show error state
-    setError(`Failed to load die image for ${type}`);
+    setError(`Failed to load die image`);
     setLoadingState('error');
   };
 
@@ -262,7 +249,7 @@ export const Die: React.FC<DieProps> = ({
         }} 
         role="status"
       >
-        <span>...</span>
+        Loading...
       </div>
     );
   }


### PR DESCRIPTION
Hey! I've fixed the issue with loading assets from the @swrpg-online/art package. The dice should now render properly in both development and production environments.

## What was fixed 

Configured Rollup to properly handle assets from external packages
Added correct path resolution for the art assets
Improved error handling for better user experience
Added tests to verify everything works

## Testing

All tests are passing and the build completes successfully:

<img width="620" alt="Screenshot 2025-04-19 at 10 39 07 PM" src="https://github.com/user-attachments/assets/c48475ab-2966-48cf-b062-c66400e85b31" />



<img width="620" alt="Screenshot 2025-04-19 at 10 39 41 PM" src="https://github.com/user-attachments/assets/636e96ef-46be-451e-b7e2-caaf697f7a9d" />

fixes #1 