### PR TITLE
Fix/direct url loading 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swrpg-online/react-dice",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "description": "React components for displaying Star Wars RPG narrative and numeric dice assets",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/Die.test.tsx
+++ b/src/Die.test.tsx
@@ -4,11 +4,13 @@ import '@testing-library/jest-dom';
 import { Die } from './Die';
 
 describe('Die Component', () => {
+  const BASE_URL = 'https://raw.githubusercontent.com/swrpg-online/art/main/dice';
+
   it('renders numeric dice with correct attributes', () => {
     const { getByAltText } = render(<Die type="d6" face={1} />);
     const img = getByAltText('d6 die showing 1');
     expect(img).toBeInTheDocument();
-    expect(img.getAttribute('src')).toContain('raw.githubusercontent.com/swrpg-online/art/main/dice/numeric/white-arabic/D6-01-Arabic-White.svg');
+    expect(img.getAttribute('src')).toBe(`${BASE_URL}/numeric/white-arabic/D6-01-Arabic-White.svg`);
   });
 
   it('applies custom styling correctly', () => {
@@ -28,13 +30,13 @@ describe('Die Component', () => {
   it('handles d4 variants correctly', () => {
     const { getByAltText } = render(<Die type="d4" face={1} variant="apex" />);
     const img = getByAltText('d4 die showing 1');
-    expect(img.getAttribute('src')).toContain('raw.githubusercontent.com/swrpg-online/art/main/dice/numeric/white-arabic/D4Apex-01-Arabic-White.svg');
+    expect(img.getAttribute('src')).toBe(`${BASE_URL}/numeric/white-arabic/D4Apex-01-Arabic-White.svg`);
   });
 
   it('renders narrative dice correctly', () => {
     const { getByAltText } = render(<Die type="boost" face="Success" />);
     const img = getByAltText('boost die showing Success');
-    expect(img.getAttribute('src')).toContain('raw.githubusercontent.com/swrpg-online/art/main/dice/narrative/Boost/Boost-Success.svg');
+    expect(img.getAttribute('src')).toBe(`${BASE_URL}/narrative/Boost/Boost-Success.svg`);
   });
 
   it('displays error state for invalid face values', () => {

--- a/src/Die.test.tsx
+++ b/src/Die.test.tsx
@@ -8,7 +8,7 @@ describe('Die Component', () => {
     const { getByAltText } = render(<Die type="d6" face={1} />);
     const img = getByAltText('d6 die showing 1');
     expect(img).toBeInTheDocument();
-    expect(img.getAttribute('src')).toContain('D6-01-Arabic-White.svg');
+    expect(img.getAttribute('src')).toContain('raw.githubusercontent.com/swrpg-online/art/main/dice/numeric/white-arabic/D6-01-Arabic-White.svg');
   });
 
   it('applies custom styling correctly', () => {
@@ -28,13 +28,13 @@ describe('Die Component', () => {
   it('handles d4 variants correctly', () => {
     const { getByAltText } = render(<Die type="d4" face={1} variant="apex" />);
     const img = getByAltText('d4 die showing 1');
-    expect(img.getAttribute('src')).toContain('D4Apex-01-Arabic-White.svg');
+    expect(img.getAttribute('src')).toContain('raw.githubusercontent.com/swrpg-online/art/main/dice/numeric/white-arabic/D4Apex-01-Arabic-White.svg');
   });
 
   it('renders narrative dice correctly', () => {
     const { getByAltText } = render(<Die type="boost" face="Success" />);
     const img = getByAltText('boost die showing Success');
-    expect(img.getAttribute('src')).toContain('Boost-Success.svg');
+    expect(img.getAttribute('src')).toContain('raw.githubusercontent.com/swrpg-online/art/main/dice/narrative/Boost/Boost-Success.svg');
   });
 
   it('displays error state for invalid face values', () => {

--- a/src/Die.tsx
+++ b/src/Die.tsx
@@ -114,19 +114,22 @@ const constructImagePath = (
   const isNumericDie = VALID_NUMERIC_DICE.includes(type as NumericDieType);
   const { style: themeStyle, script: themeScript } = parseTheme(theme);
   
+  // Base URL for the art repository
+  const baseUrl = 'https://raw.githubusercontent.com/swrpg-online/art/main/dice';
+  
   try {
     if (isNumericDie) {
       const faceStr = formatFaceNumber(face as number);
       if (type === 'd4') {
         const d4Config = getD4Config(variant);
-        return new URL(`dice/numeric/${theme}/${d4Config}-${faceStr}-${themeScript}-${themeStyle}.${format}`, 'https://raw.githubusercontent.com/swrpg-online/art/main/').href;
+        return `${baseUrl}/numeric/${theme}/${d4Config}-${faceStr}-${themeScript}-${themeStyle}.${format}`;
       } else {
         const dieType = getDieTypeName(type);
-        return new URL(`dice/numeric/${theme}/${dieType}-${faceStr}-${themeScript}-${themeStyle}.${format}`, 'https://raw.githubusercontent.com/swrpg-online/art/main/').href;
+        return `${baseUrl}/numeric/${theme}/${dieType}-${faceStr}-${themeScript}-${themeStyle}.${format}`;
       }
     } else {
       const dieTypeName = getDieTypeName(type);
-      return new URL(`dice/narrative/${dieTypeName}/${dieTypeName}-${face}.${format}`, 'https://raw.githubusercontent.com/swrpg-online/art/main/').href;
+      return `${baseUrl}/narrative/${dieTypeName}/${dieTypeName}-${face}.${format}`;
     }
   } catch (error) {
     console.error('Error constructing image path:', error);

--- a/src/Die.tsx
+++ b/src/Die.tsx
@@ -114,21 +114,23 @@ const constructImagePath = (
   const isNumericDie = VALID_NUMERIC_DICE.includes(type as NumericDieType);
   const { style: themeStyle, script: themeScript } = parseTheme(theme);
   
-  // Import from @swrpg-online/art package
-  const basePath = '@swrpg-online/art/dice';
-  
-  if (isNumericDie) {
-    const faceStr = formatFaceNumber(face as number);
-    if (type === 'd4') {
-      const d4Config = getD4Config(variant);
-      return `${basePath}/numeric/${theme}/${d4Config}-${faceStr}-${themeScript}-${themeStyle}.${format}`;
+  try {
+    if (isNumericDie) {
+      const faceStr = formatFaceNumber(face as number);
+      if (type === 'd4') {
+        const d4Config = getD4Config(variant);
+        return new URL(`dice/numeric/${theme}/${d4Config}-${faceStr}-${themeScript}-${themeStyle}.${format}`, 'https://raw.githubusercontent.com/swrpg-online/art/main/').href;
+      } else {
+        const dieType = getDieTypeName(type);
+        return new URL(`dice/numeric/${theme}/${dieType}-${faceStr}-${themeScript}-${themeStyle}.${format}`, 'https://raw.githubusercontent.com/swrpg-online/art/main/').href;
+      }
     } else {
-      const dieType = getDieTypeName(type);
-      return `${basePath}/numeric/${theme}/${dieType}-${faceStr}-${themeScript}-${themeStyle}.${format}`;
+      const dieTypeName = getDieTypeName(type);
+      return new URL(`dice/narrative/${dieTypeName}/${dieTypeName}-${face}.${format}`, 'https://raw.githubusercontent.com/swrpg-online/art/main/').href;
     }
-  } else {
-    const dieTypeName = getDieTypeName(type);
-    return `${basePath}/narrative/${dieTypeName}/${dieTypeName}-${face}.${format}`;
+  } catch (error) {
+    console.error('Error constructing image path:', error);
+    return '';
   }
 };
 


### PR DESCRIPTION

Assets from `@swrpg-online/art` weren't loading properly in consuming applications, requiring complex bundler configurations.

## Solution
Changed the asset loading strategy to use direct URLs from the source repository, making it work out of the box without any bundler configuration.

### Usage
Update to the latest version:
```bash
npm install @swrpg-online/react-dice@0.4.3
```
No additional configuration needed!

creating this since previous PR has merge conflicts

Fixes #1