### PR TITLE
Fix 6 bugs: fallback logic, missing exports, accessibility, invalid defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,32 +14,32 @@ npm install @swrpg-online/react-dice
 import { Die } from '@swrpg-online/react-dice';
 
 // Using SVG dice with Arabic numerals
-<Die type="boost" format="svg" theme="white-arabic" />
-<Die type="proficiency" format="svg" theme="black-arabic" />
+<Die type="boost" face="Success" format="svg" theme="white-arabic" />
+<Die type="proficiency" face="Triumph" format="svg" theme="black-arabic" />
 
 // Using SVG dice with Aurebesh numerals
-<Die type="boost" format="svg" theme="white-aurebesh" />
-<Die type="proficiency" format="svg" theme="black-aurebesh" />
+<Die type="boost" face="Advantage" format="svg" theme="white-aurebesh" />
+<Die type="proficiency" face="Success-Success" format="svg" theme="black-aurebesh" />
 
 // Using movie themes with Arabic numerals
-<Die type="ability" format="png" theme="anh-arabic" />
-<Die type="challenge" format="png" theme="tfa-arabic" />
+<Die type="ability" face="Success" format="png" theme="anh-arabic" />
+<Die type="challenge" face="Failure" format="png" theme="tfa-arabic" />
 
 // Using movie themes with Aurebesh numerals
-<Die type="ability" format="png" theme="anh-aurebesh" />
-<Die type="challenge" format="png" theme="tfa-aurebesh" />
+<Die type="ability" face="Advantage" format="png" theme="anh-aurebesh" />
+<Die type="challenge" face="Threat" format="png" theme="tfa-aurebesh" />
 
 // Using numeric dice with different variants
-<Die type="d4" format="svg" theme="white-arabic" variant="standard" />
-<Die type="d4" format="svg" theme="black-aurebesh" variant="apex" />
-<Die type="d4" format="svg" theme="rots-arabic" variant="base" />
+<Die type="d4" face={1} format="svg" theme="white-arabic" variant="standard" />
+<Die type="d4" face={2} format="svg" theme="black-aurebesh" variant="apex" />
+<Die type="d4" face={3} format="svg" theme="rots-arabic" variant="base" />
 
 // Other numeric dice examples
-<Die type="d6" format="png" theme="tesb-arabic" />
-<Die type="d8" format="svg" theme="rotj-aurebesh" />
-<Die type="d12" format="png" theme="tpm-arabic" />
-<Die type="d20" format="svg" theme="tlj-aurebesh" />
-<Die type="d100" format="png" theme="tros-arabic" />
+<Die type="d6" face={3} format="png" theme="tesb-arabic" />
+<Die type="d8" face={7} format="svg" theme="rotj-aurebesh" />
+<Die type="d12" face={11} format="png" theme="tpm-arabic" />
+<Die type="d20" face={20} format="svg" theme="tlj-aurebesh" />
+<Die type="d100" face={90} format="png" theme="tros-arabic" />
 ```
 
 ## Props

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ import { Die } from '@swrpg-online/react-dice';
 | Prop | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | type | string | Yes | - | The type of die to display. Can be one of: 'boost', 'proficiency', 'ability', 'setback', 'challenge', 'difficulty', 'd4', 'd6', 'd8', 'd12', 'd20', 'd100' |
+| face | number \| string | Yes | - | The face to display. For numeric dice: a number (1-based, for d100 use 0-90 in steps of 10). For narrative dice: a result string (e.g., 'Success', 'Advantage-Advantage') |
 | format | 'svg' \| 'png' | No | 'svg' | The format of the die asset to display |
 | theme | string | No | 'white-arabic' | The theme and numeral system of the die. Format is '{color}-{numerals}' or '{movie}-{numerals}' where numerals is either 'arabic' or 'aurebesh'. Movies: anh (A New Hope), rotj (Return of the Jedi), etc. |
 | variant | 'standard' \| 'apex' \| 'base' | No | 'standard' | The variant of the d4 die (only applicable when type is 'd4') |
@@ -254,7 +255,7 @@ LoadingState.Error    // 'error'
 For components that need loading state management, use the custom hook:
 
 ```typescript
-import { useLoadingState } from '@swrpg-online/react-dice/hooks';
+import { useLoadingState } from '@swrpg-online/react-dice';
 
 const MyComponent = () => {
   const { 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swrpg-online/react-dice",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "React components for displaying Star Wars RPG narrative and numeric dice assets",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/Die.test.tsx
+++ b/src/Die.test.tsx
@@ -321,6 +321,27 @@ describe('Die Component', () => {
       });
     });
 
+    it('shows error state when both SVG and PNG fallback fail', async () => {
+      const { getByAltText, queryByRole } = render(<Die type="d6" face={1} format="svg" />);
+      const img = getByAltText('d6 die showing 1');
+
+      // Initially should load SVG
+      expect(img.getAttribute('src')).toContain('.svg');
+
+      // First error: SVG fails, should fall back to PNG
+      fireEvent.error(img);
+      await waitFor(() => {
+        expect(img.getAttribute('src')).toContain('.png');
+      });
+
+      // Second error: PNG also fails, should show error state
+      fireEvent.error(img);
+      await waitFor(() => {
+        const errorDiv = queryByRole('alert');
+        expect(errorDiv).toBeInTheDocument();
+      });
+    });
+
     it('handles PNG format directly without fallback', async () => {
       const { getByAltText, queryByRole } = render(<Die type="d6" face={1} format="png" />);
       const img = getByAltText('d6 die showing 1');
@@ -515,6 +536,26 @@ describe('Die Component', () => {
   });
 
   describe('Error Messages and Accessibility', () => {
+    it('shows error when face prop is omitted for numeric die', () => {
+      const { getByRole } = render(<Die type="d6" />);
+      const errorDiv = getByRole('alert');
+      expect(errorDiv).toBeInTheDocument();
+      expect(errorDiv.getAttribute('title')).toContain('face" prop is required');
+    });
+
+    it('shows error when face prop is omitted for narrative die', () => {
+      const { getByRole } = render(<Die type="boost" />);
+      const errorDiv = getByRole('alert');
+      expect(errorDiv).toBeInTheDocument();
+      expect(errorDiv.getAttribute('title')).toContain('face" prop is required');
+    });
+
+    it('error state has aria-label for screen readers', () => {
+      const { getByRole } = render(<Die type="d6" face={10} />);
+      const errorDiv = getByRole('alert');
+      expect(errorDiv).toHaveAttribute('aria-label', 'Invalid face for d6: Must be between 1 and 6');
+    });
+
     it('provides descriptive error message for invalid die type', () => {
       const { getByRole } = render(<Die type={'invalid' as any} face={1} />);
       const errorDiv = getByRole('alert');

--- a/src/Die.tsx
+++ b/src/Die.tsx
@@ -197,7 +197,7 @@ const constructImagePath = (
  */
 export const Die: React.FC<DieProps> = ({
   type,
-  face = 1,
+  face,
   format = DEFAULT_FORMAT,
   theme = DEFAULT_THEME,
   variant = DEFAULT_D4_VARIANT,
@@ -212,11 +212,13 @@ export const Die: React.FC<DieProps> = ({
   const { state: loadingState, setLoading, setSuccess, setError: setErrorState } = useLoadingState();
   const [error, setError] = React.useState<string | null>(null);
   const [imgSrc, setImgSrc] = React.useState<string | null>(null);
+  const hasFallenBack = React.useRef(false);
   
   // On mount and when props change, validate and set the image path
   React.useEffect(() => {
     setLoading();
     setError(null);
+    hasFallenBack.current = false;
     
     try {
       // Validate die type
@@ -224,7 +226,12 @@ export const Die: React.FC<DieProps> = ({
       if (!isNumericDie && !['boost', 'proficiency', 'ability', 'setback', 'challenge', 'difficulty'].includes(type)) {
         throw new Error(`Invalid die type: ${type}`);
       }
-      
+
+      // Validate face is provided
+      if (face === undefined || face === null) {
+        throw new Error(`The "face" prop is required. Specify a valid face value for ${type} dice.`);
+      }
+
       // Validate face value
       if (isNumericDie) {
         if (typeof face !== 'number') {
@@ -262,13 +269,14 @@ export const Die: React.FC<DieProps> = ({
   
   // Handle image load error
   const handleImageError = () => {
-    // If SVG fails, try PNG
-    if (format === 'svg' && imgSrc) {
+    // If SVG fails, try PNG fallback (only once)
+    if (format === 'svg' && imgSrc && !hasFallenBack.current) {
+      hasFallenBack.current = true;
       const pngPath = imgSrc.replace(`.${format}`, '.png');
       setImgSrc(pngPath);
       return;
     }
-    
+
     setError(`Failed to load die image`);
     setErrorState();
   };
@@ -319,6 +327,7 @@ export const Die: React.FC<DieProps> = ({
         }} 
         role="alert"
         title={error || 'Error loading die'}
+        aria-label={error || 'Error loading die'}
       >
         !
       </div>

--- a/src/DieContext.tsx
+++ b/src/DieContext.tsx
@@ -146,18 +146,22 @@ export const preloadImage = (src: string): Promise<void> => {
 export const usePreloadAssets = (paths: string[]): void => {
   const context = useDieConfig();
   const pathsKey = paths.join(',');
+  const addPreloadedAsset = context?.addPreloadedAsset;
+  const preloadEnabled = context?.config.preloadAssets;
+  const preloadedAssetsRef = React.useRef(context?.preloadedAssets);
+  preloadedAssetsRef.current = context?.preloadedAssets;
 
   React.useEffect(() => {
-    if (!context?.config.preloadAssets || paths.length === 0) {
+    if (!preloadEnabled || paths.length === 0 || !addPreloadedAsset) {
       return;
     }
 
     const preloadAll = async () => {
       const promises = paths.map(async (path) => {
-        if (!context.preloadedAssets.has(path)) {
+        if (!preloadedAssetsRef.current?.has(path)) {
           try {
             await preloadImage(path);
-            context.addPreloadedAsset(path);
+            addPreloadedAsset(path);
           } catch (error) {
             console.warn(`Failed to preload asset: ${path}`, error);
           }
@@ -168,5 +172,5 @@ export const usePreloadAssets = (paths: string[]): void => {
     };
 
     preloadAll();
-  }, [pathsKey, context?.config.preloadAssets]); // Only depend on pathsKey and preloadAssets config
+  }, [pathsKey, preloadEnabled, addPreloadedAsset]);
 };

--- a/src/__snapshots__/Die.test.tsx.snap
+++ b/src/__snapshots__/Die.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Die Component Snapshot Tests matches snapshot for d100 1`] = `
 
 exports[`Die Component Snapshot Tests matches snapshot for error state 1`] = `
 <div
+  aria-label="Invalid face for d6: Must be between 1 and 6"
   class="die-error "
   role="alert"
   style="width: 50px; height: 50px; background-color: rgb(248, 215, 218); border-radius: 4px; display: flex; align-items: center; justify-content: center; color: rgb(114, 28, 36); border: 1px solid #f5c6cb; font-size: 12px; padding: 4px; text-align: center;"

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ export {
   type DieConfig,
   type DieProviderProps,
 } from './DieContext';
+export { LoadingState } from './types';
+export { useLoadingState } from './hooks/useLoadingState';
 export type {
   DieProps,
   DieType,


### PR DESCRIPTION
- Fix SVG-to-PNG fallback getting stuck when both formats fail by tracking
  fallback attempts with a ref, ensuring error state is shown properly
- Add missing LoadingState enum and useLoadingState hook exports to index.ts
  to match documented API in README
- Add aria-label to error state div for screen reader accessibility
- Fix usePreloadAssets effect dependency array using ref pattern to avoid
  stale closures without causing cascading re-runs
- Remove invalid default face=1 that caused confusing errors for narrative
  dice and d100; add explicit validation message when face prop is omitted
- Update README examples to always include required face prop

https://claude.ai/code/session_01KG7HZukesRr4hZ3Zx9vPjV